### PR TITLE
fix: replace github_username placeholder with actual username

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,7 @@ description: >- # used by seo meta and the atom feed
 url: ""
 
 github:
-  username: github_username # change to your GitHub username
+  username: peterlau123 # change to your GitHub username
 
 twitter:
   username: twitter_username # change to your Twitter username
@@ -40,7 +40,7 @@ social:
   links:
     # The first element serves as the copyright owner's link
     - https://twitter.com/username # change to your Twitter homepage
-    - https://github.com/username # change to your GitHub homepage
+    - https://github.com/peterlau123 # change to your GitHub homepage
     # Uncomment below to add more social links
     # - https://www.facebook.com/username
     # - https://www.linkedin.com/in/username

--- a/_config.yml
+++ b/_config.yml
@@ -34,13 +34,14 @@ twitter:
 social:
   # Change to your full name.
   # It will be displayed as the default author of the posts and the copyright owner in the Footer
-  name: your_full_name
-  email: example@domain.com # change to your email address
+  name: 刘鑫
+  email: lausing_image@outlook.com # change to your email address
   fediverse_handle: # fill in your fediverse handle. E.g. "@username@domain.com"
   links:
     # The first element serves as the copyright owner's link
     - https://twitter.com/username # change to your Twitter homepage
     - https://github.com/peterlau123 # change to your GitHub homepage
+    - https://www.zhihu.com/people/liu-xin-36-86-97
     # Uncomment below to add more social links
     # - https://www.facebook.com/username
     # - https://www.linkedin.com/in/username


### PR DESCRIPTION
## 问题
网站上的 GitHub 链接指向 `https://github.com/github_username`，导致 404 错误。

## 修复
- 将 `github.username` 从 `github_username` 更改为 `peterlau123`
- 更新社交链接中的 GitHub URL 为正确的地址

## 影响范围
- `_config.yml` 配置文件

## 测试
重新构建 Jekyll 站点后，GitHub 链接将正确指向 https://github.com/peterlau123