### PR TITLE
fix: Bifrost 架构图虚线标签优化——'未来'改为下方说明文字

### DIFF
--- a/_posts/2026-08-05-bifrost-agent-architecture.md
+++ b/_posts/2026-08-05-bifrost-agent-architecture.md
@@ -75,9 +75,11 @@ flowchart LR
     S1 -->|"轮询"| C1
     S1 -->|"轮询"| C2
     
-    C1 -.->|"未来"| S2
-    S2 -.->|"未来"| D1
+    C1 -.-> S2
+    S2 -.-> D1
 ```
+
+> **未来规划**：虚线表示尚未实现的通信路径。当前仅 SharedStorageBridge 落地，NetworkBridge（SSH/gRPC）为下一步方向。
 
 | 角色 | Agent 架构 | Bifrost 架构 |
 |------|-----------|--------------|


### PR DESCRIPTION
- mermaid 图中虚线边去掉'未来'标签，改为图下方 blockquote 说明
- 虚线表示尚未实现的通信路径（NetworkBridge 规划中）
- 提升可读性：标签写'未来规划'比单独'未来'更清晰